### PR TITLE
ixfrdist: Instances of lmdb::env are movable, but not copyable

### DIFF
--- a/pdns/ixfrdist-database.hh
+++ b/pdns/ixfrdist-database.hh
@@ -51,7 +51,7 @@ class IXFRDistDatabase
       auto env = lmdb::env::create();
       env.set_mapsize(1UL * 1024UL * 1024UL * 1024UL); // 1GB
       env.open(fname.c_str(), 0, 0664);
-      d_envs[d] = std::make_shared<lmdb::env>(env);
+      d_envs[d] = std::make_shared<lmdb::env>(std::move(env));
       return d_envs[d]; // TODO don't do this lookup again
     };
 };


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [ ] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
